### PR TITLE
Install Command

### DIFF
--- a/bin/actions/inject_dependency_reference_action.js
+++ b/bin/actions/inject_dependency_reference_action.js
@@ -1,0 +1,17 @@
+const ReferenceParser = require(`../parsers/reference_parser`)
+const _ = require('lodash')
+
+const injectDependencyReferenceAction = (dependencies, reference, alternateName) => {
+  return new Promise((resolve, reject) => {
+    if (reference) {
+      const { installedName } = ReferenceParser.referenceToArchiveRequest(reference, alternateName)
+
+      // TODO find a way to normalize this version?! bower wants a # (have to match this against the system type)
+      dependencies[installedName] = `${reference}`.replace(`@`, `#`)
+    }
+
+    resolve(dependencies)
+  })
+}
+
+module.exports = injectDependencyReferenceAction

--- a/bin/core/terminal.js
+++ b/bin/core/terminal.js
@@ -5,11 +5,16 @@ module.exports = {
   initializeVorpal: (vorpal, configuration) => {
     const majorVersion = parseInt(_.head(packageConfiguration.version.split(`.`)), 10)
     const applicationHandle = `${packageConfiguration.name}-${majorVersion}`
+    const NODE_COMMAND_ARGV = 2
 
     vorpal
       .delimiter(`$ `)
       .history(applicationHandle)
       .localStorage(applicationHandle)
+
+    if (_.size(process.argv) <= NODE_COMMAND_ARGV) {
+      process.argv.push(`help`)
+    }
 
     vorpal.parse(process.argv)
   }

--- a/bin/parsers/reference_parser.js
+++ b/bin/parsers/reference_parser.js
@@ -61,7 +61,7 @@ class ReferenceParser {
    */
   static __scopeToResource (scopeOrReference) {
     const patternMarkers = applicationConfiguration.get(`rules.patternMarkers`)
-    const [uri, version = ``] = this.splitURIVersion(scopeOrReference)
+    const [uri, version = `*`] = this.splitURIVersion(scopeOrReference)
     const uriAspects = uri.split(patternMarkers.separator)
     const scope = this.__matchConversionRule(uriAspects)
 

--- a/bin/support/status_log.js
+++ b/bin/support/status_log.js
@@ -143,7 +143,10 @@ class StatusLog {
       return `${content}${index + 1}. ${Colors.gray(reason)}\n`
     }, ``)
 
-    this.__logger.error(errors)
+    if (!_.isEmpty(errors)) {
+      this.__logger.error(errors)
+    }
+
     return this
   }
 }

--- a/bin/transits/git_transit.js
+++ b/bin/transits/git_transit.js
@@ -1,5 +1,6 @@
 const OperatingSystem = require('../support/operating_system')
 const VersionServant = require('../servants/version_servant')
+const StatusLog = require('../support/status_log')
 const fs = require('fs-extra')
 const _ = require('lodash')
 const os = require('os')
@@ -23,8 +24,7 @@ class GitTransit {
       return __sendToCache(archiveRequest)
         .then(resolve)
         .catch(err => {
-          console.error(err)
-
+          StatusLog.error(err, archiveRequest)
           resolve({
             installedVersion: 'x.x.x'
           })

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.7.0
 
+- ADDED show `help` if no commands are given
 - ADDED support for tracking errors during an process
 - ADDED `--save/-dev` support for `install`
 - ADDED support for honoring existing resolutions over calculated resolutions

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Klepto Changelog
 
+## 0.7.0
+
+- ADDED support for tracking errors during an process
+- ADDED `--save/-dev` support for `install`
+- ADDED support for honoring existing resolutions over calculated resolutions
+- ADDED support to write the <vault>.json file on `--save` or `--save-dev`
+- UPGRADED library dependencies to latest (axios, jszip)
+
 ## 0.6.0
 
 - ADDED `--verbose` to show all operations on console

--- a/notes/features.todo
+++ b/notes/features.todo
@@ -4,4 +4,6 @@ TODO:
   ☐ Support `archive` to package as a (zip, tar, ...)
   ☐ Support `upload` to send (http?, git, ftp, ...)
   ☐ Support `publish` which does an `archive` followed by `upload`
-  ☐ Support `--save` in `install` to update the component library
+  ✔ Support `--save` in `install` to update the component library @done (2017-11-17 09:32:49)
+  ✔ Support `--save-dev` in `install` to update the component library @done (2017-11-17 09:32:49)
+  ✔ Support integrating the resolutions of the main <system>.json with the calculated resolutions @done (2017-11-17 07:50:34)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "klepto",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -600,9 +600,9 @@
       "dev": true
     },
     "axios": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.0.tgz",
-      "integrity": "sha1-fadHkW24A/dhZR1gkdcIeJuVPGo=",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
       "requires": {
         "follow-redirects": "1.2.5",
         "is-buffer": "1.1.6"
@@ -4570,9 +4570,9 @@
       "dev": true
     },
     "jszip": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.4.tgz",
-      "integrity": "sha512-z6w8iYIxZ/fcgul0j/OerkYnkomH8BZigvzbxVmr2h5HkZUrPtk2kjYtLkqR9wwQxEP6ecKNoKLsbhd18jfnGA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+      "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
       "requires": {
         "core-js": "2.3.0",
         "es6-promise": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klepto",
   "description": "Manage components packaged in zip files",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "homepage": "https://github.com/mwjaworski/klepto",
   "author": {
     "name": "Michael Jaworski",
@@ -49,12 +49,12 @@
     "postcoveralls": "rm -Rf ./coverage"
   },
   "dependencies": {
-    "axios": "^0.17.0",
+    "axios": "^0.17.1",
     "cli-color": "1.2.0",
     "cli-spinners": "^1.1.0",
     "fs-extra": "^4.0.2",
     "is_js": "^0.9.0",
-    "jszip": "^3.1.4",
+    "jszip": "^3.1.5",
     "lodash": "4.17.4",
     "micromatch": "^3.1.4",
     "semver": "^5.4.1",

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@
 
 Klepto is a package manager supporting self-hosted archive sets. Klepto provides the standard set of package management tools, but is designed to work alongside existing bower or npm package configurations.
 
-Klepto supports archives distributed through the web, github repositories, or local folders. It supports archives being pulled from multiple sources and also searching across multiple sources.
+Klepto supports archives distributed through the web, github repositories, ftp, or local folders. It supports archives being pulled from multiple sources and also searching across multiple sources.
 
 _Archive_ is used to refer to any package Klepto can install and should be taken as a synonym for module, package, or component.
 
@@ -22,7 +22,7 @@ When Klepto installs archives it:
 
 1. Resolves the reference against configurable scoping rules (eg @internal/sub-folder/repo)
 2. Pulls and caches a zip, tar, or folder from the web, git, or local folder
-3. Reviews the _bower.json_, _package.json_ or _klepto.json_ rules to install further archives (ie. configurable per scope or url match)
+3. Reviews the _bower.json_, or _vault.json_ rules to install further archives (ie. configurable per scope or url match)
 4. All archives are placed in project archive folders, defined by the scope or match rule
 
 Klepto does not pass through any commands to existing package managers. It is a stand-alone package manager which allows a development team to distribute packages as they choose.
@@ -49,13 +49,7 @@ yarn global add klepto;
 
 ## Usage
 
-After Klepto is installed globally, you can run `klepto` from the command-line interface in interactive mode:
-
-```bash
-klepto
-```
-
-You can invoke any command as a one-off by giving the command on the command-line.
+After Klepto is installed globally, you can invoke any command as a one-off by giving the command on the command-line.
 
 ```bash
 klepto [command] <options>
@@ -66,12 +60,12 @@ klepto [command] <options>
 | Command       | Purpose
 |:--------------|:-----------------------------------------
 | `clean`       | Erase vault
+| `configure`    | (pending) Configure Kelpto RC settings
 | `download`    | Install a archive(s) to local cache
-| `install`     | Install a archive(s) to the project
-| `uninstall`   | Remove a archive to the project
-| `publish`     | (pending) Package an archive and upload
 | `initialize`  | (pending) Initialize a vault manifest
-| `settings`    | (pending) Configure Kelpto
+| `install`     | Install a archive(s) to the project
+| `publish`     | (pending) Package an archive and upload
+| `uninstall`   | Remove a archive to the project
 | `version`     | Write the current version
 
 ## License

--- a/vault.json
+++ b/vault.json
@@ -1,12 +1,21 @@
 {
   "name": "klepto",
-  "version": "0.1.0",
+  "version": "3.1.0",
   "dependencies": {
     "core-sass-brand-v3": "eabui/core-sass-brand#~3.0.0",
     "ui-sass-spacing": "eabui/ui-sass-spacing#2.0.0",
     "ui-sass-sizing": "eabui/ui-sass-sizing#2.0.0",
-    "ui-sass-border": "eabui/ui-sass-border#3.0.0"
+    "ui-sass-border": "eabui/ui-sass-border#3.0.0",
+    "ui-sass-typography": "eabui/ui-sass-typography#~3.0.0"
   },
-  "resolutions": {},
+  "devDependencies": {},
+  "resolutions": {
+    "ui-sass-spacing": "2.0.0",
+    "ui-sass-sizing": "2.0.0",
+    "ui-sass-border": "3.0.0",
+    "ui-sass-typography": "3.0.0",
+    "core-sass-brand": "2.4.0",
+    "core-sass-brand-v3": "3.1.0"
+  },
   "ignore": []
 }


### PR DESCRIPTION
- ADDED show `help` if no commands are given
- ADDED support for tracking errors during an process
- ADDED `--save/-dev` support for `install`
- ADDED support for honoring existing resolutions over calculated resolutions
- ADDED support to write the <vault>.json file on `--save` or `--save-dev`
- UPGRADED library dependencies to latest (axios, jszip)
